### PR TITLE
Change category to Solace, Java, C

### DIFF
--- a/codelabs/exploring-solace-native-apis/codelab.json
+++ b/codelabs/exploring-solace-native-apis/codelab.json
@@ -3,7 +3,7 @@
   "format": "html",
   "prefix": "https://storage.googleapis.com",
   "mainga": "UA-3921398-10",
-  "updated": "2020-06-23T21:38:20+01:00",
+  "updated": "2020-06-25T09:51:10-04:00",
   "id": "exploring-solace-native-apis",
   "duration": 67,
   "title": "Exploring Solace Native APIs - The Basics",
@@ -11,10 +11,12 @@
   "source": "exploring-solace-native-apis.md",
   "theme": "",
   "status": [
-    "draft"
+    "published"
   ],
   "category": [
-    "java"
+    "solace",
+    "java",
+    "c"
   ],
   "tags": [
     "web",

--- a/codelabs/exploring-solace-native-apis/index.html
+++ b/codelabs/exploring-solace-native-apis/index.html
@@ -60,7 +60,7 @@
       <google-codelab-step label="Prerequisites &amp; Assumptions" duration="7">
         <p>Before you start, make sure:</p>
 <ul>
-<li>You have your favourite IDE fired up and ready to go <img alt="Everyone’s favourite IDE" src="img/962d7dd94c5769a7.png"></li>
+<li>You have your favourite IDE fired up and ready to go<br><img alt="Everyone's favourite IDE" src="img/962d7dd94c5769a7.png"></li>
 <li>You have a &#34;broker&#34; set up and ready to go.  A &#34;broker&#34; could be <a href="https://console.solace.cloud/" target="_blank">Solace Cloud</a> plan, local PubSub+ software running under <a href="https://products.solace.com/download/PUBSUB_DOCKER_STAND" target="_blank">Docker</a> or a <a href="https://products.solace.com/download/PUBSUB_STAND_OVA" target="_blank">VM</a>, or even a hardware appliance if you&#39;re lucky.  Just make sure you have the client credentials, for instance &#34;client_username@messag-vpn&#34; and the password.</li>
 <li>You have &#34;no&#34; or &#34;basic&#34; authentication configured on the broker you&#39;re connecting to.  Of course we can do TLS, but that&#39;s waaaaay beyond the scope of this one...</li>
 <li>You&#39;ve <a href="https://solace.com/downloads/" target="_blank">downloaded</a>, installed or included in your dependency manager the native API of your choice</li>
@@ -70,10 +70,7 @@
 </ul>
 <aside class="special"><p>We have a lot of excellent Tutorial material available to help you get started.  This CodeLab doesn&#39;t replace those, it&#39;s here to encourage you to use them!</p>
 </aside>
-<ul>
-<li>Nice simple <a href="https://www.solace.dev/" target="_blank">Get Connected Tutorials</a></li>
-<li>More detailed <a href="https://docs.solace.com/Developer-Tutorials/Developer-Tutorials.htm" target="_blank">Developer Tutorials</a></li>
-</ul>
+<p>Nice simple <a href="https://www.solace.dev/" target="_blank">Get Connected Tutorials</a>More detailed <a href="https://docs.solace.com/Developer-Tutorials/Developer-Tutorials.htm" target="_blank">Developer Tutorials</a></p>
 <h3 is-upgraded>Cloning SolaceSamples</h3>
 <p>Create a directory in the location of your choice where you&#39;ll follow along and run the samples.  We then want to clone SolaceSamples in to your directory.  You have 3 choices:</p>
 <ul>
@@ -82,7 +79,7 @@
 <li>use your browser and pick the &#34;download&#34; button.</li>
 </ul>
 <p>As an example, using git clone for the java samples:</p>
-<pre><code>git clone https://github.com/SolaceSamples/solace-samples-java	
+<pre><code>git clone https://github.com/SolaceSamples/solace-samples-java  
 </code></pre>
 <h2 is-upgraded>Free Solace Stuff!</h2>
 <aside class="special"><p>All of the broker images and API software are available on the <a href="https://solace.com/downloads/" target="_blank">Solace Downloads Page</a>.  If you haven&#39;t already, go to it!</p>
@@ -146,7 +143,7 @@
 <p>ports that will cause failure of the container to start.</p>
 <p>#Web transport</p>
 <ul>
-<li>‘80:80&#39;		&lt;—-  Uncomment this line.</li>
+<li>‘80:80&#39;     &lt;—-  Uncomment this line.</li>
 </ul>
 </aside>
 <p>Then recreate and restart your container.</p>
@@ -198,13 +195,13 @@
 <h2 is-upgraded>1 Create the session properties</h2>
 <p>To configure the session (for instance, where should it connect to?), we create session properties and fill them out.</p>
 <p>In most samples you&#39;ll see a &#34;TopicSubscriber.&#34;  Open this is the sample language of your choice, and find the section where the session properties are filled out.</p>
-<p>Java: Go to line 57ish, under &#34;TopicSubscriber initializing...&#34;.</p>
+<p>Java:<br>Go to line 57ish, under &#34;TopicSubscriber initializing...&#34;.</p>
 <pre><code>JCSMPProperties properties = new JCSMPProperties();
 properties.setProperty(JCSMPProperties.HOST, &lt;host name or IP address&gt;);
 properties.setProperty(JCSMPProperties.USERNAME, &lt;username&gt;);
 properties.setProperty(JCSMPProperties.VPN_NAME, &lt;message VPN name&gt;);
 </code></pre>
-<p>C uses an array: Go to line 115ish, under &#34;Configure the Session properties.&#34;</p>
+<p>C uses an array:<br>Go to line 115ish, under &#34;Configure the Session properties.&#34;</p>
 <pre><code>const char     *sessionProps[50];
 int             propIndex = 0;
 sessionProps[propIndex++] = SOLCLIENT_SESSION_PROP_HOST;
@@ -258,7 +255,7 @@ public class Session {
         session.connect();
 
         while (true) { }
-	  }
+      }
 }
 </code></pre>
 <p>But it doesn&#39;t do anything!  Quite.  Read on...</p>
@@ -286,12 +283,12 @@ public class Session {
 </code></pre>
 <p>Which we then pass to the session creation call:</p>
 <pre><code>solClient_session_create ( sessionProps,
-	context_p, &amp;session_p, &amp;sessionFuncInfo, sizeof ( sessionFuncInfo ) )	
+    context_p, &amp;session_p, &amp;sessionFuncInfo, sizeof ( sessionFuncInfo ) )   
 </code></pre>
 <p>In Java, we pass the session event callback to createSession:</p>
 <pre><code>session = JCSMPFactory.onlyInstance().createSession(properties,
-		null,
-		SessionEventHandler);
+        null,
+        SessionEventHandler);
 </code></pre>
 <p>This is optional, though, but best practice says please do something with your session events, even if it&#39;s just log them.</p>
 <aside class="special"><p>If you&#39;re the kind of person that asked the teacher for extra work after you&#39;d finished the optional work before the rest of the class had finished the first question, a good exercise is to create code that prints out all session events and run it in various scenarios.</p>
@@ -310,8 +307,8 @@ public class Session {
 </code></pre>
 <p>In C, because we don&#39;t have objects we simply send the subscription request with the topic as a string (TopicSubscriber.c line 143):</p>
 <pre><code>solClient_session_topicSubscribeExt ( session_p,
-		SOLCLIENT_SUBSCRIBE_FLAGS_WAITFORCONFIRM,
-		argv[5] );
+        SOLCLIENT_SUBSCRIBE_FLAGS_WAITFORCONFIRM,
+        argv[5] );
 </code></pre>
 <p>It&#39;s no good having a subscription if we don&#39;t do anything with our messages when they arrive.  How are we going to get messages asynchronously as they arrive?  With a callback, of course.</p>
 <p>In Java, we create an object called a Message Consumer.  TopicSubscriber.java, line 72:</p>
@@ -321,9 +318,9 @@ public class Session {
 </code></pre>
 <p>In C, we create a function and add the function pointer to the session information structure.  TopicSubscriber.c, line 37:</p>
 <pre><code>solClient_rxMsgCallback_returnCode_t sessionMessageReceiveCallback(
-		solClient_opaqueSession_pt opaqueSession_p,
-		solClient_opaqueMsg_pt msg_p,
-		void *user_p ) {
+        solClient_opaqueSession_pt opaqueSession_p,
+        solClient_opaqueMsg_pt msg_p,
+        void *user_p ) {
 </code></pre>
 <p>Then at line 110:</p>
 <pre><code>    sessionFuncInfo.rxMsgInfo.callback_p = sessionMessageReceiveCallback;
@@ -486,7 +483,6 @@ Binary Attachment:                      len=15
   <script src="https://storage.googleapis.com/codelab-elements/custom-elements.min.js"></script>
   <script src="https://storage.googleapis.com/codelab-elements/prettify.js"></script>
   <script src="https://storage.googleapis.com/codelab-elements/codelab-elements.js"></script>
-  <script src="//support.google.com/inapp/api.js"></script>
 
 </body>
 </html>

--- a/markdown/exploring-solace-native-apis/exploring-solace-native-apis.md
+++ b/markdown/exploring-solace-native-apis/exploring-solace-native-apis.md
@@ -2,9 +2,9 @@ author: Tom Fairbairn
 summary: An exploration of the basics of getting started with Solace's Native APIs
 id: exploring-solace-native-apis
 tags: workshop
-categories: Java
+categories: Solace, Java, C
 environments: Web
-status: Draft
+status: Published
 feedback link: https://github.com/SolaceSamples
 analytics account: UA-3921398-10
 


### PR DESCRIPTION
Changing from category of `Java` to have `Solace` first so the logo changes. Keeping Java as a category and also adding C. Please verify Tom is good with this before merging and make sure I didn't mess anything up :)