### PR TITLE
Fix Mac Docker port

### DIFF
--- a/codelabs/get-started-basics/index.html
+++ b/codelabs/get-started-basics/index.html
@@ -166,8 +166,14 @@
 <h2 is-upgraded>Subscription Wildcards</h2>
 <p>Because published topics can be so variable and dynamic, subscribers can use wildcards to match a single subscription to multiple published topics. Solace supports two different types of wildcards:</p>
 <ul>
-<li><code>*</code> single-level wildcard, 0-or-more chars, matches up to the next level <code>/</code>. Can be used with a prefix e.g.: <code>abc*</code>, but not a suffix.</li>
-<li><code>></code> multi-level wildcard, matches <em>one</em>-or-more levels. Must occur at the end of the topic subscription.</li>
+<li><code>*</code>   Single-level wildcard, 0-or-more chars, matches up to the next level <code>/</code>.  <ul>
+<li>Can be used with a prefix e.g.: <code>abc*</code>, but not a suffix.</li>
+</ul>
+</li>
+<li><code>></code>   Multi-level wildcard, matches <em>one</em>-or-more levels.  <ul>
+<li>Must occur at the end of the topic subscription.</li>
+</ul>
+</li>
 </ul>
 <p>Some examples of Solace topic subscriptions, and topics that they match:</p>
 <ul>

--- a/codelabs/get-started-basics/index.html
+++ b/codelabs/get-started-basics/index.html
@@ -166,16 +166,37 @@
 <h2 is-upgraded>Subscription Wildcards</h2>
 <p>Because published topics can be so variable and dynamic, subscribers can use wildcards to match a single subscription to multiple published topics. Solace supports two different types of wildcards:</p>
 <ul>
-<li><code>*</code> single-level wildcard, matches up to the next level <code>/</code>. Can be used with a prefix e.g.: <code>abc*</code></li>
-<li><code>></code> multi-level wildcard, matches one-or-more levels. Must occur at the end of the topic subscription.</li>
+<li><code>*</code> single-level wildcard, 0-or-more chars, matches up to the next level <code>/</code>. Can be used with a prefix e.g.: <code>abc*</code></li>
+<li><code>></code> multi-level wildcard, matches <em>one</em>-or-more levels. Must occur at the end of the topic subscription.</li>
 </ul>
-<p>Some examples of Solace topic subscriptions:</p>
+<p>Some examples of Solace topic subscriptions, and topics that they match:</p>
 <ul>
-<li><code>hello/world/*</code></li>
-<li><code>acme/taxi/rider/></code></li>
-<li><code>city/*/*/alert/></code></li>
-<li><code>mfg/plant*/inv/update/></code></li>
-<li><code>payme/debit/*/bank01/*/ok</code></li>
+<li><code>hello/world/*</code>  <ul>
+<li>✅ <code>hello/world/aaron</code></li>
+<li>❌ <code>hello/world</code></li>
+<li>❌ <code>hello/world/solace/rules</code></li>
+</ul>
+</li>
+<li><code>acme/taxi/rider/></code>  <ul>
+<li>✅ <code>acme/taxi/rider/hail</code></li>
+<li>✅ <code>acme/taxi/rider/dropoff/051.0283/-001.7281</code></li>
+</ul>
+</li>
+<li><code>city/*/*/alert/></code>  <ul>
+<li>✅ <code>city/train/01784/alert/new</code></li>
+<li>❌ <code>city/fire/stn014/alert</code></li>
+</ul>
+</li>
+<li><code>mfg/plant*/inv/update/></code>  <ul>
+<li>✅ <code>mfg/plant/inv/update/all</code></li>
+<li>✅ `mfg/plant42/inv/update/o-rings/med/shortage&#39;</li>
+</ul>
+</li>
+<li><code>payme/debit/*/bank01/*/ok</code>  <ul>
+<li>✅ <code>payme/debit/dep/bank01/acct:12345/ok</code></li>
+<li>❌ <code>payme/debit/qr/bank01/anything/fail</code></li>
+</ul>
+</li>
 </ul>
 <p>You can read more about <a href="https://docs.solace.com/PubSub-Basics/Wildcard-Charaters-Topic-Subs.htm" target="_blank">topic wildcard subscriptions</a> here.</p>
 <aside class="special"><p>Try modifying your subscription on the Try Me! apps to use wildcards, and publish matching topics with the publisher.</p>

--- a/codelabs/get-started-basics/index.html
+++ b/codelabs/get-started-basics/index.html
@@ -166,7 +166,7 @@
 <h2 is-upgraded>Subscription Wildcards</h2>
 <p>Because published topics can be so variable and dynamic, subscribers can use wildcards to match a single subscription to multiple published topics. Solace supports two different types of wildcards:</p>
 <ul>
-<li><code>*</code> single-level wildcard, 0-or-more chars, matches up to the next level <code>/</code>. Can be used with a prefix e.g.: <code>abc*</code></li>
+<li><code>*</code> single-level wildcard, 0-or-more chars, matches up to the next level <code>/</code>. Can be used with a prefix e.g.: <code>abc*</code>, but not a suffix.</li>
 <li><code>></code> multi-level wildcard, matches <em>one</em>-or-more levels. Must occur at the end of the topic subscription.</li>
 </ul>
 <p>Some examples of Solace topic subscriptions, and topics that they match:</p>
@@ -189,7 +189,8 @@
 </li>
 <li><code>mfg/plant*/inv/update/></code>  <ul>
 <li>✅ <code>mfg/plant/inv/update/all</code></li>
-<li>✅ `mfg/plant42/inv/update/o-rings/med/shortage&#39;</li>
+<li>✅ <code>mfg/plant42/inv/update/o-rings/med/shortage</code></li>
+<li>❌ <code>mfg/123plant/inv/update/boo</code></li>
 </ul>
 </li>
 <li><code>payme/debit/*/bank01/*/ok</code>  <ul>

--- a/codelabs/get-started-basics/index.html
+++ b/codelabs/get-started-basics/index.html
@@ -76,7 +76,7 @@
 </ul>
 </li>
 </ul>
-<aside class="warning"><p><strong>NOTE:</strong> if you are running on a <strong>Mac</strong>, OSX has now reserved one of the default Solace ports: 55555. Change the port mapping in the <code>docker run</code> command above, with <code>-p 4444:55555</code></p>
+<aside class="warning"><p><strong>NOTE:</strong> if you are running on a <strong>Mac</strong>, OSX has now reserved one of the default Solace ports: 55555. Change the port mapping in the <code>docker run</code> command above, with <code>-p 55554:55555</code></p>
 </aside>
 <ul>
 <li>To run VirtualBox, VMWare, HyperV, and others: check out <a href="https://solace.com/downloads" target="_blank">solace.com/downloads</a></li>

--- a/markdown/get-started-basics/get-started-basics.md
+++ b/markdown/get-started-basics/get-started-basics.md
@@ -254,15 +254,26 @@ Each and every message can be published to a unique topic, depending on the even
 
 Because published topics can be so variable and dynamic, subscribers can use wildcards to match a single subscription to multiple published topics. Solace supports two different types of wildcards:
 
-* `*` single-level wildcard, matches up to the next level `/`. Can be used with a prefix e.g.: `abc*`
-* `>` multi-level wildcard, matches one-or-more levels. Must occur at the end of the topic subscription.
+* `*` single-level wildcard, 0-or-more chars, matches up to the next level `/`. Can be used with a prefix e.g.: `abc*`
+* `>` multi-level wildcard, matches _one_-or-more levels. Must occur at the end of the topic subscription.
 
-Some examples of Solace topic subscriptions:
+Some examples of Solace topic subscriptions, and topics that they match:
 * `hello/world/*`
+    - ✅ `hello/world/aaron`
+    - ❌ `hello/world` 
+    - ❌ `hello/world/solace/rules`
 * `acme/taxi/rider/>`
+    - ✅ `acme/taxi/rider/hail` 
+    - ✅ `acme/taxi/rider/dropoff/051.0283/-001.7281`
 * `city/*/*/alert/>`
+    - ✅ `city/train/01784/alert/new` 
+    - ❌ `city/fire/stn014/alert`
 * `mfg/plant*/inv/update/>`
+    - ✅ `mfg/plant/inv/update/all` 
+    - ✅ `mfg/plant42/inv/update/o-rings/med/shortage'
 * `payme/debit/*/bank01/*/ok`
+    - ✅ `payme/debit/dep/bank01/acct:12345/ok` 
+    - ❌ `payme/debit/qr/bank01/anything/fail`
 
 You can read more about [topic wildcard subscriptions](https://docs.solace.com/PubSub-Basics/Wildcard-Charaters-Topic-Subs.htm) here.
 

--- a/markdown/get-started-basics/get-started-basics.md
+++ b/markdown/get-started-basics/get-started-basics.md
@@ -107,7 +107,7 @@ docker run -d -p 8080:8080 -p 55555:55555 -p:8008:8008 -p:1883:1883 -p:8000:8000
    * Other Docker options are here: [https://docs.solace.com/Solace-SW-Broker-Set-Up/Docker-Containers/Set-Up-Docker-Container-Image.htm](https://docs.solace.com/Solace-SW-Broker-Set-Up/Docker-Containers/Set-Up-Docker-Container-Image.htm)
 
 Negative
-: **NOTE:** if you are running on a **Mac**, OSX has now reserved one of the default Solace ports: 55555. Change the port mapping in the `docker run` command above, with `-p 4444:55555`
+: **NOTE:** if you are running on a **Mac**, OSX has now reserved one of the default Solace ports: 55555. Change the port mapping in the `docker run` command above, with `-p 55554:55555`
 
 * To run VirtualBox, VMWare, HyperV, and others: check out [solace.com/downloads](https://solace.com/downloads)
 * Lots of other software install options are here:

--- a/markdown/get-started-basics/get-started-basics.md
+++ b/markdown/get-started-basics/get-started-basics.md
@@ -254,7 +254,7 @@ Each and every message can be published to a unique topic, depending on the even
 
 Because published topics can be so variable and dynamic, subscribers can use wildcards to match a single subscription to multiple published topics. Solace supports two different types of wildcards:
 
-* `*` single-level wildcard, 0-or-more chars, matches up to the next level `/`. Can be used with a prefix e.g.: `abc*`
+* `*` single-level wildcard, 0-or-more chars, matches up to the next level `/`. Can be used with a prefix e.g.: `abc*`, but not a suffix.
 * `>` multi-level wildcard, matches _one_-or-more levels. Must occur at the end of the topic subscription.
 
 Some examples of Solace topic subscriptions, and topics that they match:
@@ -270,7 +270,8 @@ Some examples of Solace topic subscriptions, and topics that they match:
     - ❌ `city/fire/stn014/alert`
 * `mfg/plant*/inv/update/>`
     - ✅ `mfg/plant/inv/update/all` 
-    - ✅ `mfg/plant42/inv/update/o-rings/med/shortage'
+    - ✅ `mfg/plant42/inv/update/o-rings/med/shortage`
+    - ❌ `mfg/123plant/inv/update/boo`
 * `payme/debit/*/bank01/*/ok`
     - ✅ `payme/debit/dep/bank01/acct:12345/ok` 
     - ❌ `payme/debit/qr/bank01/anything/fail`

--- a/markdown/get-started-basics/get-started-basics.md
+++ b/markdown/get-started-basics/get-started-basics.md
@@ -254,25 +254,27 @@ Each and every message can be published to a unique topic, depending on the even
 
 Because published topics can be so variable and dynamic, subscribers can use wildcards to match a single subscription to multiple published topics. Solace supports two different types of wildcards:
 
-* `*` single-level wildcard, 0-or-more chars, matches up to the next level `/`. Can be used with a prefix e.g.: `abc*`, but not a suffix.
-* `>` multi-level wildcard, matches _one_-or-more levels. Must occur at the end of the topic subscription.
+- `*`   Single-level wildcard, 0-or-more chars, matches up to the next level `/`.
+     - Can be used with a prefix e.g.: `abc*`, but not a suffix.
+- `>`   Multi-level wildcard, matches _one_-or-more levels.
+     - Must occur at the end of the topic subscription.
 
 Some examples of Solace topic subscriptions, and topics that they match:
-* `hello/world/*`
+- `hello/world/*`
     - ✅ `hello/world/aaron`
     - ❌ `hello/world` 
     - ❌ `hello/world/solace/rules`
-* `acme/taxi/rider/>`
+- `acme/taxi/rider/>`
     - ✅ `acme/taxi/rider/hail` 
     - ✅ `acme/taxi/rider/dropoff/051.0283/-001.7281`
-* `city/*/*/alert/>`
+- `city/*/*/alert/>`
     - ✅ `city/train/01784/alert/new` 
     - ❌ `city/fire/stn014/alert`
-* `mfg/plant*/inv/update/>`
+- `mfg/plant*/inv/update/>`
     - ✅ `mfg/plant/inv/update/all` 
     - ✅ `mfg/plant42/inv/update/o-rings/med/shortage`
     - ❌ `mfg/123plant/inv/update/boo`
-* `payme/debit/*/bank01/*/ok`
+- `payme/debit/*/bank01/*/ok`
     - ✅ `payme/debit/dep/bank01/acct:12345/ok` 
     - ❌ `payme/debit/qr/bank01/anything/fail`
 


### PR DESCRIPTION
 - updated the remapped port for Macs from 4444 to 55554 (which seems to be the preferred way)
 - also threw in some topic wildcard subscription examples
 - undid the "codelab.json" to that the date of the codelab doesn't change.