### PR TITLE
Updated from 'go get' to 'go install' semantics

### DIFF
--- a/markdown/codelab-4-codelab/codelab-4-codelab.md
+++ b/markdown/codelab-4-codelab/codelab-4-codelab.md
@@ -72,7 +72,7 @@ $ export PATH=$PATH:$GOROOT/bin
 **Option A: from CLI using go**
 
 ```bash
-$ go get -u -v github.com/googlecodelabs/tools/claat
+$ go install github.com/googlecodelabs/tools/claat@latest
 ```
 
 **Option B: pre-compiled binary**


### PR DESCRIPTION
Current method for installing a go application https://github.com/googlecodelabs/tools/tree/main/claat