### PR TITLE
Added warning infobox to Distributed Tracing codelab

### DIFF
--- a/markdown/dt-otel/dt-otel.md
+++ b/markdown/dt-otel/dt-otel.md
@@ -154,7 +154,19 @@ solbroker>
 
 ### Configuring the Message VPN
 
-Minimal configuration is necessary on the Message VPN. The following commands will suffice.
+The following minimal configuration is **necessary** on the Message VPN. 
+
+<aside class="negative">
+⚠️ If these steps aren't followed, your OpenTelemetry Collector logs will show 
+
+```console
+"error": "no supported auth mechanism ([ANONYMOUS])"}.
+```
+This _very clear_ 🙄 message is the Collector warning you that you're trying to connect to an unsecured resource (i.e. the broker).
+</aside>
+
+The following commands will suffice.
+
 ```console
 solbroker> enable
 solbroker# configure


### PR DESCRIPTION
Distributed Tracing configuration **requires** the broker to have authentication enabled with a proper username & password. Although the steps to do this are listed, they aren't emphasized. Consequently, Certain folks may skip these steps in the interests of time, resulting in significant effort wasted troubleshooting.

I added:

-  a "negative infobox" warning readers that username/password **must** be setup on the broker
-  the error message the Otel Collector logs if they aren't.