### PR TITLE
Fix Helm Charts Solace repo url

### DIFF
--- a/markdown/keda-solace-queue/keda-solace-queue.md
+++ b/markdown/keda-solace-queue/keda-solace-queue.md
@@ -137,7 +137,7 @@ Follow the instructions to install a Solace PubSub+ Event Broker to your Kuberne
 
 ### Add Helm repo
 ```bash
-helm repo add solacecharts https://solaceproducts.github.io/pubsubplus-kubernetes-quickstart/helm-charts
+helm repo add solacecharts https://solaceproducts.github.io/pubsubplus-kubernetes-helm-quickstart/helm-charts
 ```
 
 ### Update Helm repo


### PR DESCRIPTION
Small change in the solacecharts url to point to the correct repo